### PR TITLE
Store hasSeenReadme variable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,32 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "readme-auto-open" is now active!');
+    console.log('Readme Auto Open: activated.');
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('readme-auto-open.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from Readme Auto Open!');
-	});
+    // Check if the user has already seen the readme.md on a per workspace basis
+    const hasSeenReadme = context.workspaceState.get<boolean>('hasSeenReadme', false);
 
-	context.subscriptions.push(disposable);
+    if (!hasSeenReadme) {
+        const workspaceFolder = vscode.workspace.workspaceFolders![0].uri;
+        const readmePatterns = ['readme.md', 'README.md', 'Readme.md'];
+
+        readmePatterns.forEach(readmePattern => {
+            const readmePath = vscode.Uri.joinPath(workspaceFolder, readmePattern);
+
+            vscode.workspace.fs.stat(readmePath).then(
+                () => {
+                    // Set the flag to indicate that the user has seen the readme.md
+                    context.workspaceState.update('hasSeenReadme', true);
+                },
+                () => {
+                    // If the readme.md file does not exist, do nothing
+                    console.log('readme.md file does not exist.');
+                }
+            );
+        });
+    }
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,11 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+        "forceConsistentCasingInFileNames": true
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the `src/extension.ts` file to improve the functionality of the "Readme Auto Open" extension. The most important changes involve simplifying the activation message and adding logic to check if the user has already seen the `readme.md` file in the workspace.

Improvements to activation logic:

* Simplified the activation console message for clarity. (`src/extension.ts`)

Enhancements to user experience:

* Added logic to check if the user has already seen the `readme.md` file on a per workspace basis and set a flag accordingly. (`src/extension.ts`)
* Implemented a check for different casing variations of the `readme.md` file (`readme.md`, `README.md`, `Readme.md`). (`src/extension.ts`)

Resolves #3 