### PR TITLE
Open readme when the project opens in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,19 +3,21 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			],
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"preLaunchTask": "${defaultBuildTask}"
-		}
-	]
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--disable-extensions", // Disasble other extensions
+                "${workspaceFolder}/emptyWorkspace"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "${defaultBuildTask}"
+        }
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:readme.md"
+    "workspaceContains:[Rr][Ee][Aa][Dd][Mm][Ee].*"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -9,15 +9,12 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "workspaceContains:readme.md"
+  ],
   "main": "./out/extension.js",
   "contributes": {
-    "commands": [
-      {
-        "command": "readme-auto-open.helloWorld",
-        "title": "Hello World"
-      }
-    ]
+    "commands": []
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,33 +1,43 @@
 import * as vscode from 'vscode';
 
-export function activate(context: vscode.ExtensionContext) {
-
+export async function activate(context: vscode.ExtensionContext) {
     console.log('Readme Auto Open: activated.');
 
-    // Check if the user has already seen the readme.md on a per workspace basis
+    // Check if the user has already seen the readme on a per workspace basis
+    // A workspace is a collection of one or more folders opened in VS Code
     const hasSeenReadme = context.workspaceState.get<boolean>('hasSeenReadme', false);
 
-    if (!hasSeenReadme) {
-        const workspaceFolder = vscode.workspace.workspaceFolders![0].uri;
-        const readmePatterns = ['readme.md', 'README.md', 'Readme.md'];
-
-        readmePatterns.forEach(readmePattern => {
-            const readmePath = vscode.Uri.joinPath(workspaceFolder, readmePattern);
-
-            vscode.workspace.fs.stat(readmePath).then(
-                () => {
-                    // If the readme.md file exists, open it
-                    vscode.window.showTextDocument(readmePath);
-                    // Set the flag to indicate that the user has seen the readme.md
-                    context.workspaceState.update('hasSeenReadme', true);
-                },
-                () => {
-                    // If the readme.md file does not exist, do nothing
-                    console.log('readme.md file does not exist.');
-                }
-            );
-        });
+    if (hasSeenReadme) {
+        console.log('Readme Auto Open: readme has already been viewed.');
+        return;
     }
+
+    const readmePattern = '[Rr][Ee][Aa][Dd][Mm][Ee].*';
+
+    // Find the readme file in the root of any workspace folder in the workspace
+    const files = await vscode.workspace.findFiles(readmePattern);
+
+    if (files.length <= 0) {
+        // If the readme file does not exist, do nothing
+        return console.log(readmePattern + ' file does not exist.');
+    }
+
+    files.forEach(async (readmePath) => {
+        /*
+        * If readme is in .md format, automatically open it in document preview mode.
+        * Remark: only one preview can be opened at a time. Therefore, open .md previews if only one .md readme exists.
+        */
+        if (files.length === 1 && readmePath.fsPath.toLowerCase().endsWith('.md')) {
+            await vscode.commands.executeCommand('markdown.showPreview', readmePath);
+        } else {
+            // Open any readme file found in the workspace with preview set to false. Otherwise, only the last readme file found will be opened.
+            await vscode.window.showTextDocument(readmePath, { preview: false });
+        }
+
+        // Set the flag to indicate that the user has seen the readme
+        context.workspaceState.update('hasSeenReadme', true);
+        console.log('Readme Auto Open: ' + readmePath + ' opened.');
+    });
 }
 
 // This method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,8 @@ export function activate(context: vscode.ExtensionContext) {
 
             vscode.workspace.fs.stat(readmePath).then(
                 () => {
+                    // If the readme.md file exists, open it
+                    vscode.window.showTextDocument(readmePath);
                     // Set the flag to indicate that the user has seen the readme.md
                     context.workspaceState.update('hasSeenReadme', true);
                 },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,32 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "readme-auto-open" is now active!');
+    console.log('Readme Auto Open: activated.');
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('readme-auto-open.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from Readme Auto Open!');
-	});
+    // Check if the user has already seen the readme.md on a per workspace basis
+    const hasSeenReadme = context.workspaceState.get<boolean>('hasSeenReadme', false);
 
-	context.subscriptions.push(disposable);
+    if (!hasSeenReadme) {
+        const workspaceFolder = vscode.workspace.workspaceFolders![0].uri;
+        const readmePatterns = ['readme.md', 'README.md', 'Readme.md'];
+
+        readmePatterns.forEach(readmePattern => {
+            const readmePath = vscode.Uri.joinPath(workspaceFolder, readmePattern);
+
+            vscode.workspace.fs.stat(readmePath).then(
+                () => {
+                    // Set the flag to indicate that the user has seen the readme.md
+                    context.workspaceState.update('hasSeenReadme', true);
+                },
+                () => {
+                    // If the readme.md file does not exist, do nothing
+                    console.log('readme.md file does not exist.');
+                }
+            );
+        });
+    }
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,11 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+        "forceConsistentCasingInFileNames": true
 	}
 }


### PR DESCRIPTION
This pull request includes changes to improve the functionality and activation of the `readme-auto-open` extension. The key changes involve modifying the activation events and enhancing the logic to automatically open the `readme.md` file if it exists in the workspace.

### Improvements to extension activation:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R17): Added an activation event to trigger the extension when a `readme.md` file is detected in the workspace. Removed the predefined command from the `commands` section.

### Enhancements to extension functionality:

* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L1-R30): Simplified the activation log message and added logic to check for the existence of `readme.md` files in various capitalizations. If a `readme.md` file is found, it is opened automatically, and a flag is set to indicate that the user has seen the readme.

Resolves #5 