### PR TITLE
When readme is opened, also automatically open it in preview mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,12 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "workspaceContains:readme.md"
+  ],
   "main": "./out/extension.js",
   "contributes": {
-    "commands": [
-      {
-        "command": "readme-auto-open.helloWorld",
-        "title": "Hello World"
-      }
-    ]
+    "commands": []
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,8 @@ export function activate(context: vscode.ExtensionContext) {
 
             vscode.workspace.fs.stat(readmePath).then(
                 () => {
+                    // If the readme.md file exists, open it
+                    vscode.window.showTextDocument(readmePath);
                     // Set the flag to indicate that the user has seen the readme.md
                     context.workspaceState.update('hasSeenReadme', true);
                 },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
             vscode.workspace.fs.stat(readmePath).then(
                 () => {
                     // If the readme.md file exists, open it
-                    vscode.window.showTextDocument(readmePath);
+                    vscode.commands.executeCommand('markdown.showPreview', readmePath);
                     // Set the flag to indicate that the user has seen the readme.md
                     context.workspaceState.update('hasSeenReadme', true);
                 },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,32 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "readme-auto-open" is now active!');
+    console.log('Readme Auto Open: activated.');
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('readme-auto-open.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from Readme Auto Open!');
-	});
+    // Check if the user has already seen the readme.md on a per workspace basis
+    const hasSeenReadme = context.workspaceState.get<boolean>('hasSeenReadme', false);
 
-	context.subscriptions.push(disposable);
+    if (!hasSeenReadme) {
+        const workspaceFolder = vscode.workspace.workspaceFolders![0].uri;
+        const readmePatterns = ['readme.md', 'README.md', 'Readme.md'];
+
+        readmePatterns.forEach(readmePattern => {
+            const readmePath = vscode.Uri.joinPath(workspaceFolder, readmePattern);
+
+            vscode.workspace.fs.stat(readmePath).then(
+                () => {
+                    // Set the flag to indicate that the user has seen the readme.md
+                    context.workspaceState.update('hasSeenReadme', true);
+                },
+                () => {
+                    // If the readme.md file does not exist, do nothing
+                    console.log('readme.md file does not exist.');
+                }
+            );
+        });
+    }
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,11 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+        "forceConsistentCasingInFileNames": true
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the `readme-auto-open` extension to improve its functionality by automatically opening the `readme.md` file when a workspace is opened. The most important changes include updating the activation events in `package.json` and modifying the `activate` function in `extension.ts` to check for and open the `readme.md` file.

Changes to `package.json`:

* Added `workspaceContains:readme.md` to `activationEvents` to trigger the extension when a workspace contains a `readme.md` file. (`package.json`, [package.jsonL12-R17](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R17))
* Removed the `helloWorld` command from the `commands` section. (`package.json`, [package.jsonL12-R17](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R17))

Changes to `extension.ts`:

* Simplified the activation log message. (`src/extension.ts`, [src/extension.tsL1-R30](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L1-R30))
* Implemented logic to check for the existence of `readme.md` files and open them if they exist, and set a flag to avoid reopening the file in the same workspace. (`src/extension.ts`, [src/extension.tsL1-R30](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L1-R30))

Resolves #7 