### PR TITLE
Add reset state command and update README visibility logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,14 @@
     "workspaceContains:[Rr][Ee][Aa][Dd][Mm][Ee]"
   ],
   "main": "./out/extension.js",
-  "contributes": {},
+  "contributes": {
+    "commands": [
+      {
+        "command": "readmeAutoOpen.resetState",
+        "title": "Readme Auto Open: Reset State"
+      }
+    ]
+  },
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,24 +1,47 @@
 import * as vscode from 'vscode';
 
 const readmeRegex = /readme(\..*)?/i;
+const readmeStateKey = 'hasSeenReadme';
 
 export async function activate(context: vscode.ExtensionContext) {
-    console.log('Readme Auto Open: activated.');
+  console.log('Readme Auto Open: activated.');
+  registerResetStateCommand(context);
 
-    // We grab all the files in the root instead of using the glob-pattern to search for a README file.
-    // The reason is that glob pattern searching doesn't support support case-insensitive search, so it's easier to use a regex instead.
-    const allFilesInRootDirectory = await vscode.workspace.findFiles('*');
+  const hasSeenReadme = context.workspaceState.get<boolean>(readmeStateKey, false);
 
-    const readme = allFilesInRootDirectory.find(file => file.fsPath.match(readmeRegex));
+  if (hasSeenReadme) {
+    console.log('Readme Auto Open: User has already seen the README.');
+    return;
+  }
 
-    if (!readme) {
-      console.log('README was not found.');
-      return;
-    }
+  // We grab all the files in the root instead of using the glob-pattern to search for a README file.
+  // The reason is that glob pattern searching doesn't support support case-insensitive search, so it's easier to use a regex instead.
+  const allFilesInRootDirectory = await vscode.workspace.findFiles('*');
 
-    await vscode.window.showTextDocument(readme);
+  const readme = allFilesInRootDirectory.find(file => file.fsPath.match(readmeRegex));
 
-    console.log(`Readme Auto Open: Opened ${readme.fsPath}.`);
+  if (!readme) {
+    console.log('README was not found.');
+    return;
+  }
+
+  await vscode.window.showTextDocument(readme);
+
+  // Set the workspace state to indicate that the user has seen the README.
+  await context.workspaceState.update(readmeStateKey, true);
+
+  console.log(`Readme Auto Open: Opened ${readme.fsPath}.`);
+}
+
+function registerResetStateCommand(context: vscode.ExtensionContext) {
+  // See package.json for command information
+  const disposable = vscode.commands.registerCommand('readmeAutoOpen.resetState', async () => {
+    await context.workspaceState.update(readmeStateKey, false);
+    await vscode.window.showInformationMessage('Readme Auto Open state has been reset. Reload VSCode to see the README again.');
+    console.log('Readme Auto Open: State has been reset.');
+  });
+
+  context.subscriptions.push(disposable);
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
This pull request introduces a new command to reset the state of the "Readme Auto Open" extension and ensures that the README file is only shown once per workspace session unless the state is reset. The most important changes include adding the new command to the `package.json` file and updating the extension's activation logic to handle the new state.

New command addition:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R24): Added a new command `readmeAutoOpen.resetState` to the `contributes` section, which allows users to reset the state of the README auto-open feature.

State management and command registration:

* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R4-R15): Introduced a new constant `readmeStateKey` to manage the state indicating whether the README has been seen.
* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R30-R46): Updated the `activate` function to check the state and set it once the README is shown, ensuring the README is only opened once per session.
* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R30-R46): Added a new function `registerResetStateCommand` to register the `readmeAutoOpen.resetState` command, which resets the state and informs the user.


Resolves https://github.com/sander1095/vscode-readme-auto-open/issues/3