### PR TITLE
Open file in preview mode if it is markdown

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,12 +25,29 @@ export async function activate(context: vscode.ExtensionContext) {
     return;
   }
 
-  await vscode.window.showTextDocument(readme);
+  const readmeCanBePreviewed = readme.fsPath.toLowerCase().endsWith('.md');
+  if (readmeCanBePreviewed) {
+    console.log('Readme Auto Open: Attempting to open README in preview mode.');
+
+    try {
+      await vscode.commands.executeCommand('markdown.showPreview', readme);
+    } catch (error) {
+      console.error('Readme Auto Open: Error opening README in preview mode. It will be opened in the editor instead', error);
+      await openReadmeInEditor(readme);
+    }
+  } else {
+    await openReadmeInEditor(readme);
+  }
 
   // Set the workspace state to indicate that the user has seen the README.
   await context.workspaceState.update(readmeStateKey, true);
 
   console.log(`Readme Auto Open: Opened ${readme.fsPath}.`);
+}
+
+async function openReadmeInEditor(readme: vscode.Uri) {
+  console.log('Readme Auto Open: Opening README in text editor.');
+  await vscode.window.showTextDocument(readme);
 }
 
 function registerResetStateCommand(context: vscode.ExtensionContext) {


### PR DESCRIPTION
This pull request enhances the functionality of the `activate` function in `src/extension.ts` to provide a better user experience when opening the README file. The most important changes include adding a check to open the README in preview mode if it is a markdown file and handling errors gracefully if the preview mode fails.

Improvements to README auto-open functionality:

* Added a check to determine if the README file can be previewed (`.md` file) and attempt to open it in preview mode. (`src/extension.ts`)
* Implemented error handling to fall back to opening the README in the text editor if the preview mode fails. (`src/extension.ts`)
* Introduced a new helper function `openReadmeInEditor` to encapsulate the logic for opening the README in the text editor. (`src/extension.ts`)


Resolves #7 