### PR TITLE
README opens correctly and added unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "readme-auto-open" extension will be documented in this file.
 
+## [1.0.1] - 2024-10-16
+
+- Fix issues with incorrect files being opened when the extension loads ([#27](https://github.com/sander1095/vscode-readme-auto-open/issues/27))
+
 ## [1.0.0] - 2024-10-15
 
 - Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.8",
         "@types/node": "20.x",
+        "@types/sinon": "^17.0.3",
         "@types/vscode": "^1.94.0",
         "@typescript-eslint/eslint-plugin": "^8.7.0",
         "@typescript-eslint/parser": "^8.7.0",
@@ -19,6 +20,7 @@
         "esbuild": "^0.24.0",
         "eslint": "^9.11.1",
         "npm-run-all": "^4.1.5",
+        "sinon": "^19.0.2",
         "typescript": "^5.6.2"
       },
       "engines": {
@@ -708,6 +710,50 @@
         "node": ">=14"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
+      "integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -740,6 +786,21 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
     },
     "node_modules/@types/vscode": {
       "version": "1.94.0",
@@ -3013,6 +3074,12 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3073,6 +3140,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3355,6 +3428,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -3880,6 +3966,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -4302,6 +4397,45 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -4666,6 +4800,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "readme-auto-open",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "readme-auto-open",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "readme-auto-open",
   "displayName": "Readme Auto Open",
   "description": "A VSCode plug-in that automatically opens the README when you open a project for the first time, ensuring people read it",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "sandertenbrinke",
   "author": "Sander ten Brinke",
   "categories": [

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.8",
     "@types/node": "20.x",
+    "@types/sinon": "^17.0.3",
     "@types/vscode": "^1.94.0",
     "@typescript-eslint/eslint-plugin": "^8.7.0",
     "@typescript-eslint/parser": "^8.7.0",
@@ -70,6 +71,7 @@
     "esbuild": "^0.24.0",
     "eslint": "^9.11.1",
     "npm-run-all": "^4.1.5",
+    "sinon": "^19.0.2",
     "typescript": "^5.6.2"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   // We grab all the files in the root instead of using the glob-pattern to search for a README file.
-  // The reason is that glob pattern searching doesn't support support case-insensitive search, so it's easier to use a regex instead.
+  // The reason is that glob pattern searching doesn't support case-insensitive search, so it's easier to use a regex instead.
   const allFilesInRootDirectory = await vscode.workspace.findFiles('*');
 
   // To prevent false positives when a PATH contains the word "readme" we only consider the file name for the search.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 
-const readmeRegex = /readme(\..*)?/i;
 const readmeStateKey = 'hasSeenReadme';
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -18,14 +17,20 @@ export async function activate(context: vscode.ExtensionContext) {
   // The reason is that glob pattern searching doesn't support support case-insensitive search, so it's easier to use a regex instead.
   const allFilesInRootDirectory = await vscode.workspace.findFiles('*');
 
-  const readme = allFilesInRootDirectory.find(file => file.fsPath.match(readmeRegex));
+  // To prevent false positives when a PATH contains the word "readme" we only consider the file name.
+  const allFileNamesWithUri = allFilesInRootDirectory.map(p => {
+    const fileName = p.fsPath.split(/[\\/]/).pop();
+    return { uri: p, fileName: fileName };
+  });
 
-  if (!readme) {
+  const readme = allFileNamesWithUri.find(file => file.fileName?.match(/^readme(\..+)?$/i));
+
+  if (!readme || !readme.fileName) {
     console.log('README was not found.');
     return;
   }
 
-  const readmeCanBePreviewed = readme.fsPath.toLowerCase().endsWith('.md');
+  const readmeCanBePreviewed = readme.fileName.endsWith('.md');
   if (readmeCanBePreviewed) {
     console.log('Readme Auto Open: Attempting to open README in preview mode.');
 
@@ -33,16 +38,16 @@ export async function activate(context: vscode.ExtensionContext) {
       await vscode.commands.executeCommand('markdown.showPreview', readme);
     } catch (error) {
       console.error('Readme Auto Open: Error opening README in preview mode. It will be opened in the editor instead', error);
-      await openReadmeInEditor(readme);
+      await openReadmeInEditor(readme.uri);
     }
   } else {
-    await openReadmeInEditor(readme);
+    await openReadmeInEditor(readme.uri);
   }
 
   // Set the workspace state to indicate that the user has seen the README.
   await context.workspaceState.update(readmeStateKey, true);
 
-  console.log(`Readme Auto Open: Opened ${readme.fsPath}.`);
+  console.log(`Readme Auto Open: Opened ${readme.uri.fsPath}.`);
 }
 
 async function openReadmeInEditor(readme: vscode.Uri) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // We support both README files with and without extensions.
   // Perhaps a regex would be better, but this is simpler.
-  const readme = allFileNamesWithUri.find(file => file.fileName?.endsWith('readme') || file.fileName?.startsWith('readme.',));
+  const readme = allFileNamesWithUri.find(file => file.fileName?.endsWith('readme') || file.fileName?.startsWith('readme.'));
 
   if (!readme || !readme.fileName) {
     console.log('Readme Auto Open: README was not found.');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,29 +17,25 @@ export async function activate(context: vscode.ExtensionContext) {
   // The reason is that glob pattern searching doesn't support support case-insensitive search, so it's easier to use a regex instead.
   const allFilesInRootDirectory = await vscode.workspace.findFiles('*');
 
-  // To prevent false positives when a PATH contains the word "readme" we only consider the file name.
+  // To prevent false positives when a PATH contains the word "readme" we only consider the file name for the search.
+  // We lowercase the file name to make the search case-insensitive.
   const allFileNamesWithUri = allFilesInRootDirectory.map(p => {
-    const fileName = p.fsPath.split(/[\\/]/).pop();
+    const fileName = p?.fsPath?.split(/[\\/]/)?.pop()?.toLowerCase();
     return { uri: p, fileName: fileName };
   });
 
-  const readme = allFileNamesWithUri.find(file => file.fileName?.match(/^readme(\..+)?$/i));
+  // We support both README files with and without extensions.
+  // Perhaps a regex would be better, but this is simpler.
+  const readme = allFileNamesWithUri.find(file => file.fileName?.endsWith('readme') || file.fileName?.startsWith('readme.',));
 
   if (!readme || !readme.fileName) {
-    console.log('README was not found.');
+    console.log('Readme Auto Open: README was not found.');
     return;
   }
 
   const readmeCanBePreviewed = readme.fileName.endsWith('.md');
   if (readmeCanBePreviewed) {
-    console.log('Readme Auto Open: Attempting to open README in preview mode.');
-
-    try {
-      await vscode.commands.executeCommand('markdown.showPreview', readme);
-    } catch (error) {
-      console.error('Readme Auto Open: Error opening README in preview mode. It will be opened in the editor instead', error);
-      await openReadmeInEditor(readme.uri);
-    }
+    await openReadmeInPreviewWindow(readme.uri);
   } else {
     await openReadmeInEditor(readme.uri);
   }
@@ -53,6 +49,17 @@ export async function activate(context: vscode.ExtensionContext) {
 async function openReadmeInEditor(readme: vscode.Uri) {
   console.log('Readme Auto Open: Opening README in text editor.');
   await vscode.window.showTextDocument(readme);
+}
+
+async function openReadmeInPreviewWindow(readme: vscode.Uri) {
+  console.log('Readme Auto Open: Attempting to open README in preview mode.');
+
+  try {
+    await vscode.commands.executeCommand('markdown.showPreview', readme);
+  } catch (error) {
+    console.error('Readme Auto Open: Error opening README in preview mode. It will be opened in the editor instead');
+    await openReadmeInEditor(readme);
+  }
 }
 
 function registerResetStateCommand(context: vscode.ExtensionContext) {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -40,6 +40,7 @@ suite('Extension Test Suite', () => {
 
     const markdownFiles = [
       vscode.Uri.file('README.md'),
+      vscode.Uri.file('README.MD'),
       vscode.Uri.file('readme.MD'),
       vscode.Uri.file('reAdMe.mD'),
       vscode.Uri.file('reAdMe.test.md'),
@@ -81,6 +82,22 @@ suite('Extension Test Suite', () => {
         assert.strictEqual(executeCommandStub.called, false);
         assert.strictEqual(showTextDocumentStub.calledWith(uri), true);
       });
+    });
+  });
+
+  suite('README file fails to open', () => {
+    test(`Markdown README file fails to open in preview mode and falls back to editor`, async () => {
+      // Arrange
+      const uri = vscode.Uri.file('README.MD');
+      findFilesStub.resolves([uri]);
+      executeCommandStub.rejects(new Error('Failed to open in preview mode'));
+
+      // Act
+      await readmeAutoOpen.activate(context);
+
+      // Assert
+      assert.strictEqual(executeCommandStub.calledWith('markdown.showPreview', uri), true);
+      assert.strictEqual(showTextDocumentStub.calledWith(uri), true);
     });
   });
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,15 +1,93 @@
 import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
+import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import * as readmeAutoOpen from '../extension';
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+  vscode.window.showInformationMessage('Start all tests.');
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+  let findFilesStub: sinon.SinonStub;
+  let showTextDocumentStub: sinon.SinonStub;
+  let executeCommandStub: sinon.SinonStub;
+  let registerCommandStub: sinon.SinonStub;
+  let context: vscode.ExtensionContext;
+
+  setup(() => {
+    context = {
+      workspaceState: {
+        get: sinon.stub().returns(false),
+        update: sinon.stub().resolves()
+      },
+      subscriptions: []
+    } as unknown as vscode.ExtensionContext;
+
+    findFilesStub = sinon.stub(vscode.workspace, 'findFiles').resolves([]);
+    showTextDocumentStub = sinon.stub(vscode.window, 'showTextDocument').resolves();
+    executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves();
+    registerCommandStub = sinon.stub(vscode.commands, 'registerCommand').callsFake((command, callback) => {
+      if (command === 'readmeAutoOpen.resetState') {
+        callback();
+      }
+      return { dispose: () => { } };
+    });
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  suite('Opening README files', () => {
+    test('Markdown README found and opened in preview mode', async () => {
+      // Arrange
+      const readmeUri = vscode.Uri.file('README.md');
+      findFilesStub.resolves([readmeUri]);
+
+      // Act
+      await readmeAutoOpen.activate(context);
+
+      // Assert
+      assert.strictEqual(executeCommandStub.calledWith('markdown.showPreview', readmeUri), true);
+      assert.strictEqual(showTextDocumentStub.called, false);
+    });
+
+    test('README (non markdown) found and opened in editor', async () => {
+      // Arrange
+      const readmeUri = vscode.Uri.file('README.txt');
+      findFilesStub.resolves([readmeUri]);
+
+      // Act
+      await readmeAutoOpen.activate(context);
+
+      // Assert
+      assert.strictEqual(executeCommandStub.called, false);
+      assert.strictEqual(showTextDocumentStub.calledWith(readmeUri), true);
+    });
+  });
+
+  suite('No README files found', () => {
+    test('Nothing happens', async () => {
+      // Arrange
+      findFilesStub.resolves([]);
+
+      // Act
+      await readmeAutoOpen.activate(context);
+
+      // Assert
+      assert.strictEqual(executeCommandStub.called, false);
+      assert.strictEqual(showTextDocumentStub.called, false);
+    });
+  });
+
+  suite('Registering commands', () => {
+    test('Reset command gets registered', async () => {
+      // Arrange
+
+      // Act
+      await readmeAutoOpen.activate(context);
+
+      // Assert
+      assert.strictEqual(registerCommandStub.calledWith('readmeAutoOpen.resetState'), true);
+      sinon.assert.calledWith(context.workspaceState.update as sinon.SinonSpy, 'hasSeenReadme', false);
+    });
+  });
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -21,7 +21,7 @@ suite('Extension Test Suite', () => {
       subscriptions: []
     } as unknown as vscode.ExtensionContext;
 
-    findFilesStub = sinon.stub(vscode.workspace, 'findFiles');
+    findFilesStub = sinon.stub(vscode.workspace, 'findFiles').resolves([]);
     showTextDocumentStub = sinon.stub(vscode.window, 'showTextDocument').resolves();
     executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves();
     registerCommandStub = sinon.stub(vscode.commands, 'registerCommand').callsFake((command, callback) => {
@@ -115,10 +115,26 @@ suite('Extension Test Suite', () => {
     });
   });
 
+  // Test that the code isnt executed if readme is already seen
+  suite('User has already seen README', () => {
+    test('Nothing happens', async () => {
+      // Arrange
+      const uri = vscode.Uri.file('README.MD');
+      findFilesStub.resolves([uri]);
+      context.workspaceState.get = sinon.stub().returns(true);
+
+      // Act
+      await readmeAutoOpen.activate(context);
+
+      // Assert
+      assert.strictEqual(executeCommandStub.called, false);
+      assert.strictEqual(showTextDocumentStub.called, false);
+    });
+  });
+
   suite('Registering commands', () => {
     test('Reset command gets registered', async () => {
       // Arrange
-      findFilesStub.resolves([]);
 
       // Act
       await readmeAutoOpen.activate(context);


### PR DESCRIPTION
- Switched to a `startsWith`/`endsWith` way of working instead of regex
- Pass the `uri` to the preview window correctly.
- Added unit tests so future regressions can be caught before release

Resolves #27
Resolves #21 